### PR TITLE
Don't report threads for user reports

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -2210,12 +2210,16 @@ void kscrashreport_writeStandardReport(KSCrash_Context* const crashContext,
 
         writer->beginObject(writer, KSCrashField_Crash);
         {
-            kscrw_i_writeAllThreads(writer,
-                                    KSCrashField_Threads,
-                                    &crashContext->crash,
-                                    crashContext->config.introspectionRules.enabled,
-                                    crashContext->config.searchThreadNames,
-                                    crashContext->config.searchQueueNames);
+            // Don't write the threads for user reported crashes to improve performance
+            if(crashContext->crash.crashType != KSCrashTypeUserReported)
+            {
+                kscrw_i_writeAllThreads(writer,
+                                        KSCrashField_Threads,
+                                        &crashContext->crash,
+                                        crashContext->config.introspectionRules.enabled,
+                                        crashContext->config.searchThreadNames,
+                                        crashContext->config.searchQueueNames);
+            }
             kscrw_i_writeError(writer, KSCrashField_Error, &crashContext->crash);
         }
         writer->endContainer(writer);


### PR DESCRIPTION
For the unity notifier, there seems to be a large performance drain when trying to capture thread information.

For user reported crashes, which are all crashes reported by the Unity framework, we can skip recording threads for performance reasons. Also current iOS unity exceptions are not providing any thread data to the UI, so this shouldn't reduce the amount of information displayed.